### PR TITLE
Clear up documentation for ways to provide Codecov token

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,19 @@ after_success:
 ```
 
 ## Private Repos
-> Set `CODECOV_TOKEN` in your environment variables.
 
-Add to your `.travis.yml` file.
+You may provide your Codecov token by either:
+
+- Setting `CODECOV_TOKEN` in your environment variables and adding the following to Travis:
 ```yml
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -t uuid-repo-token
+  - bash <(curl -s https://codecov.io/bash)
 ```
-> Or you can set the environment variable `CODECOV_TOKEN` to your token.
+- Providing the Codecov token directly to the invocation by adding the following to Travis:
+```yml
+after_success:
+  - bash <(curl -s https://codecov.io/bash) -t {YOUR-TOKEN-HERE}
+```
 
 # Speed up the build
 The uploader has a *boil-the-ocean* approach, which can take a longer time to complete coverage report processing.


### PR DESCRIPTION
The documentation is very unclear regarding the fact there are two separate ways to provide a token when using the codecov.io/bash invocation. 

I myself got confused by the existing readme and thought `-t uuid-repo-token` is just some sort of a "Strategy" for pulling it from the environment vars :) 

I think the updated text makes more sense. Would love your feedback! 