### PR TITLE
chore: add FOSSA config for license compliance (example-swift)

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,11 @@
+version: 3
+
+# FOSSA CLI for getsentry/action-enforce-license-compliance.
+# https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md
+
+project:
+  id: github.com/codecov/example-swift
+  url: https://github.com/codecov/example-swift
+
+telemetry:
+  scope: "off"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# FOSSA: setuptools discovery target at repo root (add real deps here if applicable).


### PR DESCRIPTION
Adds `.fossa.yml` (FOSSA CLI v3 project metadata, telemetry off) and, when the repo has no root Python manifest, a minimal `requirements.txt` so `fossa analyze` discovers a setuptools target. Triggers **Enforce License Compliance** on PR.